### PR TITLE
Run lambda on policy change

### DIFF
--- a/iam-password-policy.yaml
+++ b/iam-password-policy.yaml
@@ -51,10 +51,31 @@ Parameters:
     - 'False'
     Default: 'True'
 Resources:
+  # This is a custom resource. Whenever it is changed (create, update, delete)
+  # the lambda below fires.
   CustomResourceConfigurePasswordPolicy:
     Type: Custom::PasswordPolicy
     Properties:
       ServiceToken: !GetAtt LambdaPasswordPolicy.Arn
+      # The below properties are here so that if you change
+      # iam-password-policy.json it triggers a change to this custom resource
+      # which triggers a call to the lambda. The properties are not actually
+      # used in this context, only in the lambda independent of these
+      # declarations. This is a cheat to make sure the lamdba is always called
+      # when you change the password policy parameters.
+      #
+      # This is particularly useful when you first start testing because you can
+      # change different policies and see the results in the IAM settings of
+      # your member accounts. You can comment the properties out if you don't
+      # want to trigger the lambda for every change to the
+      # iam-password-policy.json file.
+      MaxPasswordAgeProp: !Ref MaxPasswordAge
+      MinPasswordLengthProp: !Ref MinPasswordLength
+      RequireUppercaseCharsProp: !Ref RequireUppercaseChars
+      RequireLowercaseCharsProp: !Ref RequireLowercaseChars
+      RequireNumbersProp: !Ref RequireNumbers
+      RequireSymbolsProp: !Ref RequireSymbols
+      PasswordHistoryProp: !Ref PasswordHistory
   LambdaPasswordPolicy:
     Type: AWS::Lambda::Function
     Properties:


### PR DESCRIPTION
This change leverages the parameters for the template as properties on the custom resource such that changing the policy parameters in the iam-password-policy.json causes the lambda to fire.
